### PR TITLE
fixed manifest file to work with Firefox

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -20,5 +20,10 @@
 
     "web_accessible_resources": [
         "services/*.png"
-    ]
+    ],
+    "applications": {
+    "gecko": {
+       "id": "simpleiconification@service"
+    }
+ }
 }


### PR DESCRIPTION
Added application JSON value to prevent "corrupted extension" error when adding to Firefox